### PR TITLE
Get codes

### DIFF
--- a/pyaxis/pyaxis.py
+++ b/pyaxis/pyaxis.py
@@ -246,38 +246,40 @@ def get_codes(metadata):
         metadata: dictionary of metadata
 
     Returns:
-        dimension_code_names(list)
+        dimensions_with_codes(list)
         dimension_codes(list)
 
     """
-    dimension_code_names = []
+    dimensions_with_codes = []
     dimension_codes = []
 
-    # add CODES of STUB and HEADING to a list of dimension codes
-    stubs = metadata['STUB']
+    # add CODES of STUB to a list of dimension codes
+    stubs = metadata.get('STUB', [])
     for stub in stubs:
         stub_values = []
         code_key = 'CODES(' + stub + ')'
+        # Not all stubs necessarily have CODES
         if code_key in metadata:
-            dimension_code_names.append(stub)
+            dimensions_with_codes.append(stub)
             raw_stub_values = metadata['CODES(' + stub + ')']
             for value in raw_stub_values:
                 stub_values.append(value)
             dimension_codes.append(stub_values)
 
     # add HEADING values to the list of dimension codes
-    headings = metadata['HEADING']
+    headings = metadata.get('HEADING', [])
     for heading in headings:
         heading_values = []
         code_key = 'CODES(' + heading + ')'
+        # Not all headings necessarily have CODES
         if code_key in metadata:
-            dimension_code_names.append(heading)
+            dimensions_with_codes.append(heading)
             raw_heading_values = metadata['CODES(' + heading + ')']
             for value in raw_heading_values:
                 heading_values.append(value)
             dimension_codes.append(heading_values)
 
-    return dimension_code_names, dimension_codes
+    return dimensions_with_codes, dimension_codes
 
 
 def build_dataframe(dimension_names, dimension_members, data_values,

--- a/pyaxis/pyaxis.py
+++ b/pyaxis/pyaxis.py
@@ -238,6 +238,7 @@ def get_dimensions(metadata):
 
     return dimension_names, dimension_members
 
+
 def get_codes(metadata):
     """Read dimension codes and their dimension names from metadata dictionary.
 
@@ -277,7 +278,6 @@ def get_codes(metadata):
             dimension_codes.append(heading_values)
 
     return dimension_code_names, dimension_codes
-
 
 
 def build_dataframe(dimension_names, dimension_members, data_values,

--- a/pyaxis/pyaxis.py
+++ b/pyaxis/pyaxis.py
@@ -238,6 +238,47 @@ def get_dimensions(metadata):
 
     return dimension_names, dimension_members
 
+def get_codes(metadata):
+    """Read dimension codes and their dimension names from metadata dictionary.
+
+    Args:
+        metadata: dictionary of metadata
+
+    Returns:
+        dimension_code_names(list)
+        dimension_codes(list)
+
+    """
+    dimension_code_names = []
+    dimension_codes = []
+
+    # add CODES of STUB and HEADING to a list of dimension codes
+    stubs = metadata['STUB']
+    for stub in stubs:
+        stub_values = []
+        code_key = 'CODES(' + stub + ')'
+        if code_key in metadata:
+            dimension_code_names.append(stub)
+            raw_stub_values = metadata['CODES(' + stub + ')']
+            for value in raw_stub_values:
+                stub_values.append(value)
+            dimension_codes.append(stub_values)
+
+    # add HEADING values to the list of dimension codes
+    headings = metadata['HEADING']
+    for heading in headings:
+        heading_values = []
+        code_key = 'CODES(' + heading + ')'
+        if code_key in metadata:
+            dimension_code_names.append(heading)
+            raw_heading_values = metadata['CODES(' + heading + ')']
+            for value in raw_heading_values:
+                heading_values.append(value)
+            dimension_codes.append(heading_values)
+
+    return dimension_code_names, dimension_codes
+
+
 
 def build_dataframe(dimension_names, dimension_members, data_values,
                     null_values, sd_values):

--- a/pyaxis/test/unit/test_pyaxis.py
+++ b/pyaxis/test/unit/test_pyaxis.py
@@ -94,6 +94,7 @@ def test_get_dimensions():
     assert dimension_members[0][0] == 'Total'
     assert dimension_members[3][3] == 'Divorciados/as'
 
+
 def test_get_codes():
     """Should return two lists (dimension names with codes and codes)."""
     pc_axis = pyaxis.read(
@@ -101,14 +102,14 @@ def test_get_codes():
         'iso-8859-15')
     metadata_elements, raw_data = pyaxis.metadata_extract(pc_axis)
     metadata = pyaxis.metadata_split_to_dict(metadata_elements)
-    dimension_code_names, dimension_codes = pyaxis.get_codes(metadata)
+    dimensions_with_codes, dimension_codes = pyaxis.get_codes(metadata)
     assert len(dimension_codes) == 1
-    assert len(dimension_code_names) == 1
-    assert dimension_code_names[0] == 'Comunidad Autónoma de residencia del matrimonio'
+    assert len(dimensions_with_codes) == 1
+    assert dimensions_with_codes[0] == 'Comunidad Autónoma de residencia del matrimonio'
     assert dimension_codes[0][6] == 'CA06'
     assert dimension_codes[0][11] == 'CA11'
-    
 
+    
 def test_build_dataframe():
     """Should return a dataframe with n+1 columns (dimensions + data)."""
     null_values=r'^"\."$'

--- a/pyaxis/test/unit/test_pyaxis.py
+++ b/pyaxis/test/unit/test_pyaxis.py
@@ -94,6 +94,20 @@ def test_get_dimensions():
     assert dimension_members[0][0] == 'Total'
     assert dimension_members[3][3] == 'Divorciados/as'
 
+def test_get_codes():
+    """Should return two lists (dimension names with codes and codes)."""
+    pc_axis = pyaxis.read(
+        data_path + '14001.px',
+        'iso-8859-15')
+    metadata_elements, raw_data = pyaxis.metadata_extract(pc_axis)
+    metadata = pyaxis.metadata_split_to_dict(metadata_elements)
+    dimension_code_names, dimension_codes = pyaxis.get_codes(metadata)
+    assert len(dimension_codes) == 1
+    assert len(dimension_code_names) == 1
+    assert dimension_code_names[0] == 'Comunidad Autónoma de residencia del matrimonio'
+    assert dimension_codes[0][6] == 'CA06'
+    assert dimension_codes[0][11] == 'CA11'
+    
 
 def test_build_dataframe():
     """Should return a dataframe with n+1 columns (dimensions + data)."""


### PR DESCRIPTION
My use case required extracting the codes from the .px, so I implemented a function that is very similar to get_dimensions(). I though about adding an optional parameter which would allow the user to have these codes added to the generated dataframe but though that maybe that would add complexity you wouldn't want. Let me know if that is something you would want, because obviously now it is not immediately obvious to the user that getting the codes is possible and adding them to the dataframe requires a few extra steps.