### PR TITLE
Fix/multilanguage

### DIFF
--- a/pyaxis/metadata_processing.py
+++ b/pyaxis/metadata_processing.py
@@ -145,7 +145,8 @@ def metadata_dict_maker(metadata_dict, languages, lang):
             #check if multilingual key
             if "["+lang+"]" in key:
                 # remove the default language that has just been added
-                del lang_dict[previous_key]
+                if 'previous_key' in locals() and previous_key in lang_dict:
+                    del lang_dict[previous_key]
                 # remove language info from key
                 key = brackets_stripper(key)
                 # Add the value only the language requested


### PR DESCRIPTION
Hi
I downloaded the PX file here:
https://www.bfs.admin.ch/bfs/de/home/statistiken/kriminalitaet-strafrecht/polizei/kantonale-statistiken.assetdetail.34887167.html

I was only able to load the file with lang=‘de’ or without any lang specification (default also 'de'). All other languages resulted in the same key error.
When checking the source code, I noticed that ‘previous_key’ is not initialized. I fixed this bug and checked the loading of data with all languages (‘de’, ‘it’, ‘fr’, ‘en’) without errors.
It would be great if you could include this in the next release.

Happy coding ;-)

Best, Léonie (Tomcatreadytofly)